### PR TITLE
Fixed blank email during registration

### DIFF
--- a/src/e_cidadania/apps/userprofile/forms.py
+++ b/src/e_cidadania/apps/userprofile/forms.py
@@ -113,7 +113,8 @@ class RegistrationForm(forms.Form):
         """
         email = self.cleaned_data.get("email")
 
-        if not email: return  email
+        if not email:
+            raise forms.ValidationError(_("E-mail address cannot be blank"))
 
         try:
             User.objects.get(email=email)

--- a/src/e_cidadania/apps/userprofile/templates/userprofile/account/registration.html
+++ b/src/e_cidadania/apps/userprofile/templates/userprofile/account/registration.html
@@ -35,7 +35,7 @@
                 </div>
 
                 <div class="clearfix {% if form.email.errors %}error{% endif%}">
-                    <label for="prependedInput">{% trans "E-mail (optional)" %}</label>
+                    <label for="prependedInput">{% trans "E-mail" %}</label>
                     <div class="input">
                         {{ form.email }}
                         <span class="help-inline">

--- a/src/e_cidadania/apps/userprofile/views.py
+++ b/src/e_cidadania/apps/userprofile/views.py
@@ -300,9 +300,8 @@ def register(request):
             password = form.cleaned_data.get('password1')
             newuser = User.objects.create_user(username=username, email='', password=password)
 
-            if form.cleaned_data.get('email'):
-                newuser.email = form.cleaned_data.get('email')
-                EmailValidation.objects.add(user=newuser, email=newuser.email)
+            newuser.email = form.cleaned_data.get('email')
+            EmailValidation.objects.add(user=newuser, email=newuser.email)
 
             newuser.save()
             return HttpResponseRedirect('%scomplete/' % request.path_info)


### PR DESCRIPTION
Previously it was possible to supply blank email and register on the site. Now, a ValidationError is raised if the field is left blank.
