### PR TITLE
Removed unnecessary arguments in email_validation_reset 

### DIFF
--- a/src/e_cidadania/apps/userprofile/views.py
+++ b/src/e_cidadania/apps/userprofile/views.py
@@ -314,7 +314,7 @@ def register(request):
     return render_to_response(template, data, context_instance=RequestContext(request))
 
 @login_required
-def email_validation_reset(request, space_name):
+def email_validation_reset(request):
     """
     Resend the validation email for the authenticated user.
     """


### PR DESCRIPTION
The argument space_name is not used inside the function email_validation_reset function. It is raising TypeError at /accounts/email/validation/reset/
email_validation_reset() takes exactly 2 arguments (1 given)
It has been fixed.
