### PR TITLE
Fix the exception occured after location modification is done

### DIFF
--- a/src/e_cidadania/apps/userprofile/templates/userprofile/profile/location_done.html
+++ b/src/e_cidadania/apps/userprofile/templates/userprofile/profile/location_done.html
@@ -8,7 +8,7 @@
     <div class="row">
         <div class="span12">
             <h3>{% trans "Your profile information has been updated successfully" %}.</h3>
-            <p><a href="{% url 'profile-overview' %}">{% trans "Go back to your profile" %}</p>
+            <p><a href="{% url 'profile_overview' %}">{% trans "Go back to your profile" %}</p>
         </div>
     </div>
 


### PR DESCRIPTION
When the location modification is submitted, an exception will occur, this is caused by line 11 of the file "apps/userprofile/templates/userprofile/profile/location_done.html", it should be "profile_overview", instead of "profile-overview".
