### PR TITLE
Space characters must be lowercase, digits or underscore

### DIFF
--- a/src/e_cidadania/apps/spaces/forms.py
+++ b/src/e_cidadania/apps/spaces/forms.py
@@ -24,10 +24,19 @@ documents, meetings and entities. Most of the forms are directly generated
 from the data models.
 """
 
+import re
+
+from django import forms
 from django.forms import ModelForm
 from django.forms.models import modelformset_factory
 
 from e_cidadania.apps.spaces.models import Space, Document, Event, Entity
+
+def is_valid_space_url(space_url):
+    if re.match('^[a-z0-9_]+$', space_url):
+        return True
+    else:
+        return False
 
 class SpaceForm(ModelForm):
     
@@ -41,6 +50,13 @@ class SpaceForm(ModelForm):
     """
     class Meta:
         model = Space
+
+    def clean_url(self):
+        space_url = self.cleaned_data['url']
+        if not is_valid_space_url(space_url):
+            raise forms.ValidationError("Invalid characters in the space URL.")
+        else:
+            return space_url
 
 # Create a formset for entities. This formset can be attached to any other form
 # but will be usually attached to SpaceForm

--- a/src/e_cidadania/apps/spaces/models.py
+++ b/src/e_cidadania/apps/spaces/models.py
@@ -49,7 +49,7 @@ class Space(models.Model):
     name = models.CharField(_('Name'), max_length=250, unique=True,
                             help_text=_('Max: 250 characters'))
     url = models.CharField(_('URL'), max_length=100, unique=True,
-                            help_text=_('All lowercase. This will be the \
+                            help_text=_('Valid characters are lowercase, digits and underscores. This will be the \
                                         accesible URL'))
     description = models.TextField(_('Description'),
                                     default=_('Write here your description.'))


### PR DESCRIPTION
Code has been added which ensures that permissible characters in the space URL field are lowercase, digits and underscore only.
