### PR TITLE
Fix the little bug of news publishing.

### DIFF
--- a/src/e_cidadania/apps/news/views.py
+++ b/src/e_cidadania/apps/news/views.py
@@ -51,7 +51,7 @@ class AddPost(FormView):
     
     def get_success_url(self):
         self.space = get_object_or_404(Space, url=self.kwargs['space_name'])
-        return '/spaces/' + self.space.name
+        return '/spaces/' + self.space.url
         
     def form_valid(self, form):
         self.space = get_object_or_404(Space, url=self.kwargs['space_name'])


### PR DESCRIPTION
After publishing a new news item the redirection url should be 'space.url' instead of 'space.name'.
