### PR TITLE
Restricted chars in space URLs and updated the description text

### DIFF
--- a/src/e_cidadania/apps/spaces/forms.py
+++ b/src/e_cidadania/apps/spaces/forms.py
@@ -24,19 +24,10 @@ documents, meetings and entities. Most of the forms are directly generated
 from the data models.
 """
 
-import re
-
-from django import forms
 from django.forms import ModelForm
 from django.forms.models import modelformset_factory
 
 from e_cidadania.apps.spaces.models import Space, Document, Event, Entity
-
-def is_valid_space_url(space_url):
-    if re.match('^[a-z0-9_]+$', space_url):
-        return True
-    else:
-        return False
 
 class SpaceForm(ModelForm):
     
@@ -50,13 +41,6 @@ class SpaceForm(ModelForm):
     """
     class Meta:
         model = Space
-
-    def clean_url(self):
-        space_url = self.cleaned_data['url']
-        if not is_valid_space_url(space_url):
-            raise forms.ValidationError("Invalid characters in the space URL.")
-        else:
-            return space_url
 
 # Create a formset for entities. This formset can be attached to any other form
 # but will be usually attached to SpaceForm

--- a/src/e_cidadania/apps/spaces/models.py
+++ b/src/e_cidadania/apps/spaces/models.py
@@ -49,7 +49,7 @@ class Space(models.Model):
     name = models.CharField(_('Name'), max_length=250, unique=True,
                             help_text=_('Max: 250 characters'))
     url = models.CharField(_('URL'), max_length=100, unique=True,
-                            help_text=_('Valid characters are lowercase, digits and underscores. This will be the \
+                            help_text=_('All lowercase. This will be the \
                                         accesible URL'))
     description = models.TextField(_('Description'),
                                     default=_('Write here your description.'))

--- a/src/e_cidadania/apps/spaces/models.py
+++ b/src/e_cidadania/apps/spaces/models.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with e-cidadania. If not, see <http://www.gnu.org/licenses/>.
 
+from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import User
@@ -49,8 +50,12 @@ class Space(models.Model):
     name = models.CharField(_('Name'), max_length=250, unique=True,
                             help_text=_('Max: 250 characters'))
     url = models.CharField(_('URL'), max_length=100, unique=True,
-                            help_text=_('All lowercase. This will be the \
-                                        accesible URL'))
+                            validators=[RegexValidator(
+                                        regex='^[a-z0-9_]+$',
+                                        message='Invalid characters in the space URL.'
+                                       )],
+                            help_text=_('Valid characters are lowercase, digits and \
+                                         underscore. This will be the accesible URL'))
     description = models.TextField(_('Description'),
                                     default=_('Write here your description.'))
     date = models.DateTimeField(_('Date of creation'), auto_now_add=True)

--- a/src/e_cidadania/apps/spaces/templates/spaces/space_add.html
+++ b/src/e_cidadania/apps/spaces/templates/spaces/space_add.html
@@ -204,7 +204,7 @@
             <h4>{% trans "How to add new spaces" %}</h4><br/>
             <ul class="instructions">
                 <li><strong>{% trans "Space name" %}</strong>: {% trans "The name of the space. Have in mind that this name will be used as the URL of your space. We recommend to use all lowercase. (100 chars)" %}</li>
-                <li><strong>{% trans "Description" %}</strong>: {% trans "An optional description for your space. It won't be showed to the users, but to the admins." %}</li>
+                <li><strong>{% trans "Description" %}</strong>: {% trans "An optional description for your space. This is publicly visible to everyone." %}</li>
                 <li><strong>{% trans "Logotype" %}</strong>: {% trans "An image of 75px height and 100px width." %}</li>
                 <li><strong>{% trans "Banner" %}</strong>: {% trans "Another image. 75px height." %}</li>
                 <li><strong>{% trans "Authorized groups" %}</strong>: {% trans "This will set up what users can access to your space." %}</li>

--- a/src/e_cidadania/apps/spaces/views.py
+++ b/src/e_cidadania/apps/spaces/views.py
@@ -189,7 +189,7 @@ class ViewSpaceIndex(DetailView):
         
         messages.warning(self.request, _("You're not registered to this space."))
         self.template_name = 'not_allowed.html'
-        return space_object.none()
+        return space_object
 
     # Get extra context data
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
The following are the changes I've made.
1. Space URL chars must be lowercase, digits or underscore: reimplemented it using the RegexValidator class of Django.
2. Updated text displayed when a space is being added to tell user that Description of a space is publicly visible.
