### PR TITLE
People can no longer send invitations anonymous invitations to other people: Fixes #191

### DIFF
--- a/src/e_cidadania/apps/userprofile/templates/userprofile/account/login.html
+++ b/src/e_cidadania/apps/userprofile/templates/userprofile/account/login.html
@@ -62,7 +62,7 @@
         <a href="{% url 'signup' %}">{% trans "Sign up!" %}</a><br />
         {% endif %}
         <h4>{% trans "Invite your friends" %}</h4>
-        <a href="{% url 'invite' %}">{% trans "Via e-mail" %}</a><br />
+        <a href="{% url 'invite' %}">{% trans "Via e-mail(login required)" %}</a><br />
         <a href="https://twitter.com/share?text=Come to e-cidadania&url={{ uri }}">{% trans "Via Twitter" %}</a><br />
         <a href="https://www.facebook.com/sharer.php?u={{ uri }}&t=Invitation to e-cidadania">{% trans "Via Facebook" %}</a><br />
         <a href="https://plusone.google.com/_/+1/confirm?hl=en&url={{ uri }}">{% trans "Via Google Plus" %}</a><br />

--- a/src/e_cidadania/views.py
+++ b/src/e_cidadania/views.py
@@ -191,6 +191,7 @@ class ListNews(ListView):
 
         return news
 
+@login_required
 def invite(request):
 
     """


### PR DESCRIPTION
It's now mandatory to login before inviting people to join e-cidadania.
