### PR TITLE
Fix for chrome-browser automatic translation that broke Jqueryui-datepicker

### DIFF
--- a/src/apps/ecidadania/debate/templates/debate/debate_add.html
+++ b/src/apps/ecidadania/debate/templates/debate/debate_add.html
@@ -165,7 +165,7 @@ automatically if found in the data models.
                 <label class="control-label">{{ form.start_date.label }}</label>
                 <div class="controls">
                     <div class="input-append">
-                        <input type="text" name="start_date" id="datepicker-start" class="hasDatePicker">
+                        <input type="text" name="start_date" id="datepicker-start" class="hasDatePicker notranslate">
                         {% if form.start_date.help_text %}
                             <span class="add-on"><a href="#" rel="tooltip" title="{{ form.start_date.help_text }}"><i class="icon-question-sign"></i></a></span>
                         {% endif %}
@@ -184,7 +184,7 @@ automatically if found in the data models.
                 <label class="control-label">{{ form.end_date.label }}</label>
                 <div class="controls">
                     <div class="input-append">
-                        <input type="text" name="end_date" id="datepicker-end" class="hasDatePicker">
+                        <input type="text" name="end_date" id="datepicker-end" class="hasDatePicker notranslate">
                         {% if form.end_date.help_text %}
                             <span class="add-on"><a href="#" rel="tooltip" title="{{ form.end_date.help_text }}"><i class="icon-question-sign"></i></a></span>
                         {% endif %}

--- a/src/apps/ecidadania/voting/templates/voting/poll_form.html
+++ b/src/apps/ecidadania/voting/templates/voting/poll_form.html
@@ -98,7 +98,7 @@ This is a form to create a new poll. It uses poll_board.js file to add new choic
                 <label class="control-label">{{ form.start_date.label }}</label>
                 <div class="controls">
                     <div class="input-append">
-                        <input type="text" name="start_date" id="datepicker-start" class="hasDatePicker">
+                        <input type="text" name="start_date" id="datepicker-start" class="hasDatePicker notranslate">
                         {% if form.start_date.help_text %}
                         <span class="add-on"><a href="#" rel="tooltip" title="{{ form.start_date.help_text }}"><i class="icon-question-sign"></i></a></span>
                         {% endif %}
@@ -117,7 +117,7 @@ This is a form to create a new poll. It uses poll_board.js file to add new choic
                 <label class="control-label">{{ form.end_date.label }}</label>
                 <div class="controls">
                     <div class="input-append">
-                        <input type="text" name="end_date" id="datepicker-end" class="hasDatePicker">
+                        <input type="text" name="end_date" id="datepicker-end" class="hasDatePicker notranslate">
                         {% if form.end_date.help_text %}
                         <span class="add-on"><a href="#" rel="tooltip" title="{{ form.end_date.help_text }}"><i class="icon-question-sign"></i></a></span>
                         {% endif %}

--- a/src/apps/ecidadania/voting/templates/voting/voting_form.html
+++ b/src/apps/ecidadania/voting/templates/voting/voting_form.html
@@ -136,7 +136,7 @@
                         {% if form.title.value %}
                         {{ form.start_date }}
                         {% else %}
-                        <input type="text" name="start_date" id="datepicker-start" class="hasDatePicker" />
+                        <input type="text" name="start_date" id="datepicker-start" class="hasDatePicker notranslate" />
                         {% endif %}
                         {% if form.start_date.help_text %}
                         <span class="add-on"><a href="#" rel="tooltip" title="{{ form.start_date.help_text }}"><i class="icon-question-sign"></i></a></span>
@@ -155,7 +155,7 @@
                 <label class="control-label">{{ form.end_date.label }}</label>
                 <div class="controls">
                     <div class="input-append">
-                        <input type="text" name="end_date" id="datepicker-end" class="hasDatePicker">
+                        <input type="text" name="end_date" id="datepicker-end" class="hasDatePicker notranslate">
                         {% if form.end_date.help_text %}
                         <span class="add-on"><a href="#" rel="tooltip" title="{{ form.end_date.help_text }}"><i class="icon-question-sign"></i></a></span>
                         {% endif %}

--- a/src/core/spaces/templates/spaces/event_form.html
+++ b/src/core/spaces/templates/spaces/event_form.html
@@ -68,7 +68,7 @@ automatically if found in the data models.
                         {% if form.title.value %}
                             {{ form.event_date }}
                         {% else %}
-                            <input type="text" name="event_date" id="datepicker" class="hasDatePicker">
+                            <input type="text" name="event_date" id="datepicker" class="hasDatePicker notranslate">
                         {% endif %}
                         {% if form.event_date.help_text %}
                             <span class="add-on"><a href="#" rel="tooltip" title="{{ form.event_date.help_text }}"><i class="icon-question-sign"></i></a></span>

--- a/src/e_cidadania/static_files/css/screen.css
+++ b/src/e_cidadania/static_files/css/screen.css
@@ -711,6 +711,12 @@ table {
 .votes {
   visibility:hidden;
 }
+
+/* Empty class for jqueryui-datepicker translate fix */
+
+.notranslate{
+}
+
 /*^END VOTES AND POLLS */
 
 /************************************************


### PR DESCRIPTION
This should fix the conversion of properly formed date to NaN/NaN/NaN which was due to chrome translating on its own ( which in-turn broke Jqueryui-datepicker date format)

**fix** : added a dummy class notranslate that stops chrome from translating that particular input field.  
