### PR TITLE
[Fixed] Minor bug encountered during voting for a poll

### DIFF
--- a/src/apps/ecidadania/voting/views/polls.py
+++ b/src/apps/ecidadania/voting/views/polls.py
@@ -252,8 +252,16 @@ def vote_poll(request, poll_id, space_url):
     .. versionadded:: 0.1.5
     """
     space = get_object_or_404(Space, url=space_url)
-    choice = get_object_or_404(Choice, pk=request.POST['choice'])
     poll = get_object_or_404(Poll, pk=poll_id)
+    try :
+	choice = get_object_or_404(Choice, pk=request.POST['choice'])
+    except KeyError:
+    	return render_to_response('voting/poll_detail.html', {
+		    'poll': poll,
+		    'get_place': space,
+		    'error_message': "You didn't select a choice.",
+		    }, context_instance=RequestContext(request))
+
 
     if request.method == 'POST' and has_space_permission(request.user, space,
     allow=['admins', 'mods', 'users']):


### PR DESCRIPTION
**Steps to reproduce the bug**
1. Open any poll .
2. Without selecting any option , click vote.

**Error** : "Key 'choice' not found in <QueryDict: {u'csrfmiddlewaretoken': [u'xxxxxxxxxxx.....xxx']}>"

**Expected outcome** : Some error message that notifies the user to select a choice should be thrown and then user should be allowed to leave the page ( after voting, that is).

**Fix** : The user stays on the same page  if he doesn't select a valid option , with an error message that reads "You didn't select any choice" .
