### PR TITLE
Forgot password link in site index updated

### DIFF
--- a/src/e_cidadania/templates/site_index.html
+++ b/src/e_cidadania/templates/site_index.html
@@ -63,7 +63,7 @@
                         </div>
                     </form>
                     <div style="font-size:0.8em;">
-                        <a href="#">{% trans "Forgot your password?" %}</a> | 
+                        <a href="http://ecidadania.org/accounts/password/reset/">{% trans "Forgot your password?" %}</a> | 
                         <a href="{% url 'invite' %}">{% trans "Invite someone!" %}</a>
                     </div>
                 </div>


### PR DESCRIPTION
The forgot password link in the site index was empty. It is now link to the password reset page. 
