### PR TITLE
CSS Error Solved - Logo and Banner aligned together

### DIFF
--- a/src/core/spaces/templates/spaces/space_form.html
+++ b/src/core/spaces/templates/spaces/space_form.html
@@ -148,7 +148,7 @@ tempalte shows the help_text automatically if found in the data models.
                     </label>
                     <div class="controls">
                         <div class="row">
-                            <div class="span4">
+                            <div class="span2">
                                 {% if get_place %}
                                 <img src="{{ MEDIA_URL }}{{ get_place.banner }}" />
                                 {% endif %}


### PR DESCRIPTION
While creating a space, the upload box were not aligned properly.
So made the div class same in both logo and banner option same

vishrut009
