### PR TITLE
The changes made in the spaces.py file, regarding the mostcommented field, have a serious bug

### DIFF
--- a/src/core/spaces/views/spaces.py
+++ b/src/core/spaces/views/spaces.py
@@ -145,12 +145,14 @@ class ViewSpaceIndex(DetailView):
         # databass
         place_url = self.kwargs['space_url']
         place = get_or_insert_object_in_cache(Space, place_url, url=place_url)
+        '''posts_by_score = Comment.objects.filter(is_public=True) \
+            .values('object_pk').annotate(score=Count('id')).order_by('-score')'''
         posts_by_score = Comment.objects.filter(is_public=True) \
             .values('object_pk').annotate(score=Count('id')).order_by('-score')
         post_ids = [int(obj['object_pk']) for obj in posts_by_score]
         top_posts = Post.objects.filter(space=place.id).in_bulk(post_ids)
         # print top_posts.values()[0].title
-        o_list = Comment.objects.annotate(ocount=Count('object_pk'))
+# o_list = Comment.objects.annotate(ocount=Count('object_pk'))
 
         context['entities'] = Entity.objects.filter(space=place.id)
         context['documents'] = Document.objects.filter(space=place.id)

--- a/src/core/spaces/views/spaces.py
+++ b/src/core/spaces/views/spaces.py
@@ -162,7 +162,7 @@ class ViewSpaceIndex(DetailView):
         context['mostviewed'] = Post.objects.filter(space=place.id) \
                                                     .order_by('-views')[:5]
 #context['mostcommented'] = [top_posts.get(id,None) for id in post_ids]
-	context['mostcommented']=top_posts.values()
+	context['mostcommented'] = filter(None,map(lambda x: top_posts.get(x,None),post_ids))
         # context['mostcommented'] = sorted(o_list,
         #     key=lambda k: k['ocount'])[:10]
         # print sorted(o_list, key=lambda k: k['ocount'])[:10]

--- a/src/core/spaces/views/spaces.py
+++ b/src/core/spaces/views/spaces.py
@@ -161,7 +161,8 @@ class ViewSpaceIndex(DetailView):
                                                     .order_by('-pub_date')[:5]
         context['mostviewed'] = Post.objects.filter(space=place.id) \
                                                     .order_by('-views')[:5]
-        context['mostcommented'] = [top_posts.get(id,None) for id in post_ids]
+#context['mostcommented'] = [top_posts.get(id,None) for id in post_ids]
+	context['mostcommented']=top_posts.values()
         # context['mostcommented'] = sorted(o_list,
         #     key=lambda k: k['ocount'])[:10]
         # print sorted(o_list, key=lambda k: k['ocount'])[:10]


### PR DESCRIPTION
In the line : context['mostcommented'] = [top_posts.get(id,None) for id in post_ids]

post_ids is a list that contains all the posts that have been made, in all the spaces combined.
top_posts however has been filtered for the current space.
This means that whenever .get method would find an id that exists in some space other than the current space( which automatically exists in the post_ids ), it would return a None, that would get appended to the list, hence the context['mostcommented'] would have a None in it as one of its element.
This would cause an error.

However, if we simply do a .values on the dictionary that contains the posts specific to the current space, we would not get any None element in the context['mostcommented'].

Example:

Suppose we have two spaces called spaceone and spacetwo, now we also have two comments, one in each of them.
Suppose we are currently inside spacetwo:

```
the post_ids ==[1,2]
top_posts={=2:<post: hello>}
Now if we do a .get on top_posts with id==1 from post_ids, we would be returned a default value = None.
so the context['mostcommented']==[None,<post:hello>]
```

However the .values method would just return
    context['mostcommented']=[post:hello]
    because it hasn't enquired for post_id==1, which belongs to another space and has already been filtered out in top_posts

Refer to lines 140-165 in spaces.py for clearer understanding of the issue.

Also, this doesn't solve the mostcommented thing, as even now , the comments aren't sorted, I'll do that as soon as I get some time.
