### PR TITLE
Admin is not able to edit the debate he created.

### DIFF
--- a/src/apps/ecidadania/debate/views.py
+++ b/src/apps/ecidadania/debate/views.py
@@ -125,7 +125,7 @@ def add_new_debate(request, space_url):
 @permission_required('debate.change_debate')
 def edit_debate(request, space_url, debate_id):
 
-
+    pk = debate_id
     place = get_object_or_404(Space, url=space_url)
 
     if has_operation_permission(request.user, place, 'debate.change_debate', \


### PR DESCRIPTION
When the admin tries to log in and edit a debate that he had previously created, he is not able to do so. An error occurs indicating that a certain variable of the name 'pk' has not been defined, in /src/apps/debate/views.py in edit_debate function (line 172).

It has been fixed by initializing pk.
=> pk = debate_id 

inside the 'edit_debate' function.
